### PR TITLE
Watchfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,17 @@ To help you compose, the editor
 To help you typeset, the editor
 
 - [x] detects project settings (e.g. CommandChar)
-- [ ] auto-completes your tag functions
 - [x] warns unbalanced braces
+- [x] provides document preview
+- [x] reloads preview (only when pollen syntax is correct) during editing
+- [ ] auto-completes your tag functions
 - [ ] warns runtime errors in your document
 - [ ] warns undefined tag functions
 - [ ] inlines Racket document
-- [x] provides document preview
-- [x] reloads preview during editing
 
 Also, the server
 
-- [ ] watches file changes and reload your preview page if you choose
-  to use your own editor.
+- [x] watches file changes and auto-reloads your pages.
 
 *Note:*
 - [x] means the feature has been implemented.
@@ -71,6 +70,10 @@ raco pkg install pollen-rock
 `raco pollen-rock -h` shows available options.
 
 # ChangeLog
+## 0.3.0 (03/07/2017)
+Features
+
+- The preview page file content change
 ## 0.2.0 (03/06/2017)
 Features
 

--- a/info.rkt
+++ b/info.rkt
@@ -9,8 +9,8 @@
 
 (define build-deps '("scribble-lib" "racket-doc"))
 ;(define scribblings '(("scribblings/pollen-rock.scrbl" ())))
-(define pkg-desc "pollen-rock is an in-browser editor (and a server) for Pollen publishing system.")
-(define version "0.2.0")
+(define pkg-desc "pollen-rock is a Pollen server and an in-browser editor for Pollen publishing system.")
+(define version "0.3.0")
 (define pkg-authors '("Junsong Li"))
 
 (define raco-commands

--- a/pollen-rock/api.rkt
+++ b/pollen-rock/api.rkt
@@ -257,7 +257,6 @@ This file defines protocols between clients and server
   (define ans
     (make-hasheq `((rendered-resource . ,(resource->output-path resource))
                    (seconds . 0))))
-  (println ans)
   (define (handler _ last-mod)
     (hash-set! ans 'seconds last-mod))
   (when (file-watch filepath handler last-seen-seconds)

--- a/pollen-rock/config.rkt
+++ b/pollen-rock/config.rkt
@@ -9,15 +9,27 @@
 (define webroot (current-directory))
 (define-runtime-path runtimeroot ".")
 
-;;; names for signifying editing page
+;;; names for dispatching queries
 
 ;; add query on url to signify edit action
 (define query-edit-name "edit")
 (define/contract (url-mark-edit url)
-  (-> string? string?)
-  (append-path "/edit" url))
+  (-> resource? resource?)
+  (string-list->resource
+   (cons query-edit-name (resource->path-elements url))))
 
 ;; TODO: this is supposed to return a resource!
+(define query-watch-name "watchfile")
 (define/contract (url-mark-watch url)
-  (-> string? string?)
-  (append-path "/watchfile" url))
+  (-> resource? resource?)
+  (string-list->resource
+   (cons query-watch-name (resource->path-elements url))))
+
+(module+ test
+  (require rackunit)
+  (check-equal? (url-mark-edit "/page1/index.html")
+                (string-list->resource
+                 (list query-edit-name "page1" "index.html")))
+  (check-equal? (url-mark-watch "/dir1/dir2/index.html")
+                (string-list->resource
+                 (list query-watch-name "dir1" "dir2" "index.html"))))

--- a/pollen-rock/config.rkt
+++ b/pollen-rock/config.rkt
@@ -15,21 +15,21 @@
 (define query-edit-name "edit")
 (define/contract (url-mark-edit url)
   (-> resource? resource?)
-  (string-list->resource
+  (path-elements->resource
    (cons query-edit-name (resource->path-elements url))))
 
 ;; TODO: this is supposed to return a resource!
 (define query-watch-name "watchfile")
 (define/contract (url-mark-watch url)
   (-> resource? resource?)
-  (string-list->resource
+  (path-elements->resource
    (cons query-watch-name (resource->path-elements url))))
 
 (module+ test
   (require rackunit)
   (check-equal? (url-mark-edit "/page1/index.html")
-                (string-list->resource
+                (path-elements->resource
                  (list query-edit-name "page1" "index.html")))
   (check-equal? (url-mark-watch "/dir1/dir2/index.html")
-                (string-list->resource
+                (path-elements->resource
                  (list query-watch-name "dir1" "dir2" "index.html"))))

--- a/pollen-rock/config.rkt
+++ b/pollen-rock/config.rkt
@@ -16,3 +16,8 @@
 (define/contract (url-mark-edit url)
   (-> string? string?)
   (append-path "/edit" url))
+
+;; TODO: this is supposed to return a resource!
+(define/contract (url-mark-watch url)
+  (-> string? string?)
+  (append-path "/watchfile" url))

--- a/pollen-rock/css/index.css
+++ b/pollen-rock/css/index.css
@@ -32,17 +32,41 @@ body {
     border-bottom: 1px solid #AAA;
 }
 
-.collection-item:hover, .collection-item:hover a {
+.collection-item:hover {
     background: #f4faff;
 }
 
-.collection-item a {
+.collection-item .edit-url a {
     color: #555;
     text-decoration: none;
 }
 
-.collection-item a:hover {
+.collection-item .edit-url a:hover {
     color: #000;
+    text-decoration: none;
+}
+
+.watch-url {
+    float: right;
+}
+
+.btn {
+    cursor: pointer;
+    cursor: hand;
+    padding: 0 4px;
+    border-radius: 3px;
+    border: none;
+    background-color: #424242;
+    z-index: 2;
+}
+a.btn {
+    color: #eceff1;
+    text-decoration: none;
+}
+
+a.btn:hover {
+    background-color: #212121;
+    color: #eceff1;
     text-decoration: none;
 }
 

--- a/pollen-rock/css/watchfile.css
+++ b/pollen-rock/css/watchfile.css
@@ -36,7 +36,7 @@ html {
 }
 
 #dead {
-    background-color: #1a237e;
+    background-color: #212121;
     color: #EEE;
     position: absolute;
     left: 0;

--- a/pollen-rock/css/watchfile.css
+++ b/pollen-rock/css/watchfile.css
@@ -1,0 +1,18 @@
+#preview-loader {
+    position: absolute;
+    top: 0;
+    left: 0;
+    margin: 0;
+    padding: 0;
+}
+
+#preview-data {
+    height: 100%;
+    width: 100%;
+}
+
+#preview-frame {
+    height: 100vh;
+    width: 100vw;
+    border: none;
+}

--- a/pollen-rock/css/watchfile.css
+++ b/pollen-rock/css/watchfile.css
@@ -14,6 +14,7 @@ html {
 #preview-data {
     height: 100%;
     width: 100%;
+    overflow: hidden;
 }
 
 #preview-frame {

--- a/pollen-rock/css/watchfile.css
+++ b/pollen-rock/css/watchfile.css
@@ -1,3 +1,8 @@
+html {
+    /* use a random font to overwrite roboto */
+    font-family: monospace;
+}
+
 #preview-loader {
     position: absolute;
     top: 0;
@@ -15,4 +20,27 @@
     height: 100vh;
     width: 100vw;
     border: none;
+}
+
+.toast {
+    font-size: 0.9rem;
+}
+.toast-info {
+    background-color: #DFF0D8;
+    color: #468847;
+}
+
+.toast-error {
+    background-color: #FFE2E2;
+    color: #EF3434;
+}
+
+#dead {
+    background-color: #1a237e;
+    color: #EEE;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
 }

--- a/pollen-rock/fs-watch.rkt
+++ b/pollen-rock/fs-watch.rkt
@@ -1,0 +1,76 @@
+#lang racket
+
+(require openssl/md5)
+(provide file-watch)
+
+(define (file-checksum filepath)
+  (with-input-from-file filepath
+    (lambda ()
+      (md5 (current-input-port)))))
+
+(define (directory-list-all folderpath)
+  (define (list-all-files folder)
+    (for/list [(f (directory-list folder #:build? #t))]
+      (if (directory-exists? f)
+          (list-all-files f)
+          f)))
+  (if (not (directory-exists? folderpath))
+      (list)
+      (flatten (list-all-files folderpath))))
+
+;; can't watch added new files for now.
+;; removing file event will be ignored.
+(define/contract (folder-watch folderpath callback)
+  (-> path-string? (-> path-string? any/c) any/c)
+  (define files (directory-list-all folderpath))
+  (define file-cache
+    (make-hash
+     (map (lambda (f)
+            (cons f (file-or-directory-modify-seconds f)))
+          files)))
+  (let loop ()
+    (define evts
+      (for/list [(file-modtime (hash->list file-cache))]
+        (define fname (car file-modtime))
+        (define modtime (cdr file-modtime))
+        (handle-evt (filesystem-change-evt fname)
+                    (lambda (_)
+                      (cond [(file-exists? fname)
+                             (define last-mod
+                               (file-or-directory-modify-seconds fname))
+                             (unless (= last-mod modtime)
+                               (callback fname)
+                               (hash-set! file-cache fname last-mod))]
+                            [else
+                             (hash-remove! file-cache fname)])
+                      (loop)))))
+    (apply sync evts)))
+
+(define (file-watch filepath callback [last-seen-seconds #f] [noexit #f])
+  (define cur-mod (file-or-directory-modify-seconds filepath))
+  (cond [(or (not last-seen-seconds)
+             (= last-seen-seconds cur-mod))
+         (let loop ([last-mod cur-mod])
+           (sync
+            (handle-evt
+             (filesystem-change-evt filepath)
+             (lambda (_)
+               (define cur-mod (file-or-directory-modify-seconds filepath))
+               (cond [(not (file-exists? filepath))
+                      (error 'file-watch "file is removed. Not yet implemented.")]
+                     [(= last-mod cur-mod)
+                      (loop cur-mod)]
+                     [noexit
+                      (callback filepath cur-mod)
+                      (loop cur-mod)]
+                     [else
+                      (callback filepath cur-mod)])))))]
+        [(< last-seen-seconds cur-mod)
+         (callback filepath cur-mod)]
+        [else
+         ;; last-seen-seconds is greater than cur-mod. No idea why,
+         ;; send back cur-mode to let the frontend update its time
+         (callback filepath cur-mod)]))
+
+;(folder-watch "." (lambda (f) (println (format "file ~a changed." f))))
+;(file-watch "1" (lambda (f) (println (format "file ~a changed." f))) #t)

--- a/pollen-rock/http-util.rkt
+++ b/pollen-rock/http-util.rkt
@@ -12,7 +12,7 @@
   (-> request? resource?)
   (define uri (request-uri req))
   (define string-list (map path/param-path (url-path uri)))
-  (string-list->resource string-list))
+  (path-elements->resource string-list))
 
 ;; construct a response contains only text
 ;; example: (response/text "1" "2" "3")

--- a/pollen-rock/js/watchfile.js
+++ b/pollen-rock/js/watchfile.js
@@ -91,13 +91,15 @@ $(document).ready(function() {
     },
     reload: function(src) {
       loaderView.show();
+      this.frame.on('load', function(){
+        loaderView.hide();
+      });
       if (this.frame.attr('src')) {
         var doc = this.frame.contents()[0];
         doc.location.reload(true);
       } else {
         this.frame.attr('src', src);
       }
-      loaderView.hide();
     }
   };
 

--- a/pollen-rock/js/watchfile.js
+++ b/pollen-rock/js/watchfile.js
@@ -1,0 +1,41 @@
+$(document).ready(function() {
+  "use strict";
+
+  // 0 will be used as known last modification seconds when seconds
+  // is not passed in.
+  function watchFileRequest(resource, seconds) {
+    return {
+      type : 'watchfile',
+      resource : resource,
+      seconds : seconds || 0
+    };
+  }
+
+  var resource = $("#preview-data").attr("data");
+  var lastSeenSeconds = 0;
+  var frame = $("#preview-frame");
+
+  function watch() {
+    var wfRequest = watchFileRequest(resource, lastSeenSeconds);
+    $.post("/api", wfRequest, function(res){
+      var result = JSON.parse(res);
+      if (! result["rendered-resource"] || result.seconds == 0) {
+        console.log("corrupted response.");
+      }
+      lastSeenSeconds = result.seconds;
+      if (frame.attr('src')) {
+        var doc = frame.contents()[0];
+        doc.location.reload(true);
+      } else {
+        frame.attr('src', result["rendered-resource"]);
+      }
+      watch();
+    }).fail(function() {
+      console.log("failed. continue");
+      watch();
+    }).always(function() {
+    });
+  }
+
+  watch();
+});

--- a/pollen-rock/js/watchfile.js
+++ b/pollen-rock/js/watchfile.js
@@ -1,6 +1,8 @@
 $(document).ready(function() {
   "use strict";
 
+  var serverAPI = "/api";
+
   // 0 will be used as known last modification seconds when seconds
   // is not passed in.
   function watchFileRequest(resource, seconds) {
@@ -11,31 +13,105 @@ $(document).ready(function() {
     };
   }
 
-  var resource = $("#preview-data").attr("data");
-  var lastSeenSeconds = 0;
-  var frame = $("#preview-frame");
+  var model = {
+    init: function() {
+      this.lastSeenSeconds = 0;
+      this.resource = $("#preview-data").attr("data");
+      this.retry = 0;
+    }
+  };
 
-  function watch() {
-    var wfRequest = watchFileRequest(resource, lastSeenSeconds);
-    $.post("/api", wfRequest, function(res){
-      var result = JSON.parse(res);
-      if (! result["rendered-resource"] || result.seconds == 0) {
-        console.log("corrupted response.");
-      }
-      lastSeenSeconds = result.seconds;
-      if (frame.attr('src')) {
-        var doc = frame.contents()[0];
+  var ctrl = {
+    init: function() {
+      model.init();
+      deadView.init();
+      loaderView.init();
+      preview.init();
+      notifyView.info("Watching " + model.resource);
+    },
+
+    watch: function() {
+      var wfRequest = watchFileRequest(model.resource,
+                                       model.lastSeenSeconds);
+      $.post(serverAPI, wfRequest, function(res){
+        var result = JSON.parse(res);
+        if (! result["rendered-resource"] || result.seconds == 0) {
+          notifyView.info("corrupted response. Continue to connect...");
+        }
+        model.lastSeenSeconds = result.seconds;
+        preview.reload(result["rendered-resource"]);
+        model.retry = 0;
+        ctrl.watch();
+      }).fail(function(status) {
+        // depends on file system changes, the request may be sent out
+        // in the middle of an replace operation, retry a few times if
+        // failed.
+        model.retry += 1;
+        if (model.retry <= 10) {
+          loaderView.show();
+          setTimeout(function() {
+            loaderView.hide();
+            ctrl.watch();
+          }, 1000);
+        } else {
+          notifyView.error("Server error. Stop connecting.");
+          loaderView.hide();
+          deadView.show();
+        }
+      });
+    }
+  };
+
+  var loaderView = {
+    init: function() {
+      this.view = $("#preview-loader");
+      this.hide();
+    },
+    show: function() {
+      this.view.show();
+    },
+    hide: function() {
+      this.view.hide();
+    }
+  };
+
+  var notifyView = {
+    info : function(msg) {
+      Materialize.toast(msg, 4000, 'toast-info');
+    },
+    error : function(msg) {
+      console.log("error: "+msg);
+      Materialize.toast(msg, 4000, 'toast-error');
+    }
+  };
+
+  var preview = {
+    init: function() {
+      this.frame = $("#preview-frame");
+    },
+    reload: function(src) {
+      loaderView.show();
+      if (this.frame.attr('src')) {
+        var doc = this.frame.contents()[0];
         doc.location.reload(true);
       } else {
-        frame.attr('src', result["rendered-resource"]);
+        this.frame.attr('src', src);
       }
-      watch();
-    }).fail(function() {
-      console.log("failed. continue");
-      watch();
-    }).always(function() {
-    });
-  }
+      loaderView.hide();
+    }
+  };
 
-  watch();
+  var deadView = {
+    init: function() {
+      this.view = $("#dead");
+      this.view.hide();
+    },
+    show: function() {
+      this.view.show();
+    }
+  };
+
+  ctrl.init();
+
+  ctrl.watch();
 });

--- a/pollen-rock/main.rkt
+++ b/pollen-rock/main.rkt
@@ -60,14 +60,14 @@
            (next-dispatcher))]))
 
 (define (edit-handler req trimmed-url)
-  (define resource (string-list->resource trimmed-url))
+  (define resource (path-elements->resource trimmed-url))
   (define breadcrumb (xexpr/resource->breadcrumb resource))
   (define filepath (append-path webroot resource))
   (define content (file->bytes filepath))
   (response/text (include-template "editor.html")))
 
 (define (watchfile-handler req url)
-  (define resource (string-list->resource url))
+  (define resource (path-elements->resource url))
   (response/text (include-template "watchfile.html")))
 
 (define-values (server-dispatch url)

--- a/pollen-rock/main.rkt
+++ b/pollen-rock/main.rkt
@@ -16,6 +16,12 @@
 (require "http-util.rkt")
 (require racket/cmdline)
 
+(define server-port (make-parameter 8000))
+
+;; preview only indicates that no editor functionality is needed
+(define preview-only (make-parameter #f))
+
+
 ;;; Debug use
 (define (print-request req)
   (let ((uri (request-uri req)))
@@ -60,13 +66,16 @@
   (define content (file->bytes filepath))
   (response/text (include-template "editor.html")))
 
+(define (watchfile-handler req url)
+  (define resource (string-list->resource url))
+  (response/text (include-template "watchfile.html")))
+
 (define-values (server-dispatch url)
   (dispatch-rules
    [("edit" (string-arg) ...) edit-handler]
    [("api") #:method "post" api-post-handler]
+   [("watchfile" (string-arg) ...) watchfile-handler]
    [((string-arg) ...) index-handler]))
-
-(define server-port (make-parameter 8000))
 
 ;; add runtimeroot to serve pollen-rock's static files when indexing.
 ;; add webroot to serve users' own static files
@@ -78,8 +87,12 @@
       [("-p" "--port")
        ,(lambda (flag port)
           (server-port (string->number port)))
-       (,(format "server's port (default ~a)" (server-port))
-        "port")]))
+       (,(format "set server's port (default ~a)" (server-port))
+        "port")]
+      [("-u" "--preview-only")
+       ,(lambda (flag)
+          (preview-only #t))
+       (,(format "auto render and reload pages when file changes. (default ~a)" (preview-only)))]))
    (lambda (f) (void))
    '())
   (serve/servlet server-dispatch

--- a/pollen-rock/model.rkt
+++ b/pollen-rock/model.rkt
@@ -11,7 +11,7 @@
 (struct file (name resource directory? ptype)
         #:transparent
         #:guard (lambda (name res dir? ptype tmp)
-                  (unless (absolute-path? res)
+                  (unless (resource? res)
                     (error 'file (format "resource is not absolute path: ~a" res)))
                   (values name res dir? ptype)))
 
@@ -36,9 +36,12 @@
     (error 'data/all-files
            (format "resource ~a not found on ~a." resource webroot)))
   (define names (map path->string (directory-list disk-path)))
-  (define urls  (map (lambda (n) (append-path resource n)) names))
+  (define urls  (map (lambda (n)
+                       (path-elements->resource
+                        `(,@(resource->path-elements resource) ,n)))
+                     names))
   (define files-dir? (map directory-exists?
-  					     (map (lambda (n) (append-path disk-path n)) names)))
+                          (map (lambda (n) (append-path disk-path n)) names)))
   (define pollen-types (map data/pollentype urls))
   (map file names urls files-dir? pollen-types))
 

--- a/pollen-rock/util.rkt
+++ b/pollen-rock/util.rkt
@@ -27,6 +27,11 @@
   (-> string? boolean?)
   (string-prefix? r "/"))
 
+;; take each path element out
+(define/contract (resource->path-elements r)
+  (-> resource? (listof string?))
+  (map path->string (rest (explode-path r))))
+
 ;; assemble url component into a resource
 (define/contract (string-list->resource lst)
   (-> (listof string?) resource?)
@@ -57,6 +62,11 @@
   (define (check-path-equal? p1 p2)
     (check-equal? (normal-case-path p1)
                   (normal-case-path p2)))
+
+  (check-equal? (resource->path-elements "/") '())
+  (check-equal? (resource->path-elements "/1") '("1"))
+  (check-equal? (resource->path-elements "/1/2/3/") '("1" "2" "3"))
+  (check-equal? (resource->path-elements "/1/2/3") '("1" "2" "3"))
 
   (check-equal? (resource->breadcrumb-url "/") (list))
   (check-equal? (resource->breadcrumb-url "/a")

--- a/pollen-rock/util.rkt
+++ b/pollen-rock/util.rkt
@@ -33,7 +33,7 @@
   (map path->string (rest (explode-path r))))
 
 ;; assemble url component into a resource
-(define/contract (string-list->resource lst)
+(define/contract (path-elements->resource lst)
   (-> (listof string?) resource?)
   (string-append "/" (string-join lst "/")))
 
@@ -46,7 +46,7 @@
   (define components (map ->string (rest (explode-path resource))))
   (define accumulated (for/list ([i (in-range 1 (+ 1 (length components)))])
                         (take components i)))
-  (map string-list->resource accumulated))
+  (map path-elements->resource accumulated))
 
 
 (define/contract (resource->output-path resource)
@@ -67,6 +67,21 @@
   (check-equal? (resource->path-elements "/1") '("1"))
   (check-equal? (resource->path-elements "/1/2/3/") '("1" "2" "3"))
   (check-equal? (resource->path-elements "/1/2/3") '("1" "2" "3"))
+
+  (check-equal? (path-elements->resource '()) "/")
+  (check-equal? (path-elements->resource '("1")) "/1")
+  (check-equal? (path-elements->resource '("1" "2")) "/1/2")
+
+  (check-equal? (resource->output-path "/1.html.pp") "/1.html")
+  (check-equal? (resource->output-path "/1.html.pmd") "/1.html")
+  (check-equal? (resource->output-path "/1.html.p") "/1.html")
+  (check-equal? (resource->output-path "/1.html.pm") "/1.html")
+
+  (check-true (is-pollen-source? "/1.html.pp"))
+  (check-true (is-pollen-source? "/1.html.pm"))
+  (check-true (is-pollen-source? "/1.html.pmd"))
+  (check-true (is-pollen-source? "/1.html.p"))
+  (check-false (is-pollen-source? "/1.html"))
 
   (check-equal? (resource->breadcrumb-url "/") (list))
   (check-equal? (resource->breadcrumb-url "/a")

--- a/pollen-rock/view.rkt
+++ b/pollen-rock/view.rkt
@@ -46,8 +46,12 @@
   (define ptypes  (map ctrl/file-ptype files))
 
   (define (link name url ptype)
-    (let ((modified-url (if ptype (url-mark-edit url) url)))
-      `(a ((href ,modified-url)) ,name)))
+    (let ((modified-url (if ptype (url-mark-edit url) url))
+          (watch-url (if ptype (url-mark-watch url) #f)))
+      `(div (span ((class "edit-url")) (a ((href ,modified-url)) ,name))
+            ,@(if watch-url
+                 `((span ((class "watch-url")) (a ((class "btn") (href ,watch-url)) "Watch")))
+                 `()))))
   (ui-collections (map link names resources ptypes)))
 
 (define/contract (xexpr/resource->breadcrumb resource)

--- a/pollen-rock/watchfile.html
+++ b/pollen-rock/watchfile.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Watching @|resource|</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="/css/materialize.min.css">
+    <link rel="stylesheet" href="/css/watchfile.css">
+  </head>
+
+  <body>
+    <!--<div id="preview-loader" class="progress">
+      <div class="indeterminate"></div>
+    </div>-->
+    <div id="preview-data" data="@|resource|">
+      <iframe id="preview-frame"></iframe>
+    </div>
+    <script src="/js/jquery-3.1.1.min.js"></script>
+    <script src="/js/watchfile.js"></script>
+  </body>
+</html>

--- a/pollen-rock/watchfile.html
+++ b/pollen-rock/watchfile.html
@@ -11,13 +11,18 @@
   </head>
 
   <body>
-    <!--<div id="preview-loader" class="progress">
+    <div id="preview-loader" class="progress">
       <div class="indeterminate"></div>
-    </div>-->
+    </div>
     <div id="preview-data" data="@|resource|">
       <iframe id="preview-frame"></iframe>
     </div>
+    <div id="dead" class="valign-wrapper" style="display: none;">
+      <div style="margin: 0 auto;">Server seems dead...Try to reload?</div>
+    </div>
+
     <script src="/js/jquery-3.1.1.min.js"></script>
+    <script src="/js/materialize.min.js"></script>
     <script src="/js/watchfile.js"></script>
   </body>
 </html>


### PR DESCRIPTION
These changesets implement file watching. When the watching file is changed, the browser will auto-reload the page.

This function is implemented largely in the server, where frontend sends a watchfile long polling request to the server to watch a file change. The server will respond the request only when a file is changed. frontend reloads the page when the request returns and the rest of control flow follows normal HTTP GET request.

File change is detected via a file's modify time. File checksum function is also pushed in the code base, but that's not used. checksum could be more effective, but that seems not necessary, and modify time is way cheaper than the checksum.